### PR TITLE
Fix async params type in CCCD detail page

### DIFF
--- a/src/app/cccd/[id]/page.tsx
+++ b/src/app/cccd/[id]/page.tsx
@@ -4,7 +4,8 @@ import { fetchCccdDetail } from "@/lib/api";
 
 export const dynamic = "force-dynamic";
 
-export default async function CccdDetailPage({ params }: { params: { id: string } }) {
+export default async function CccdDetailPage(props: Promise<{ params: { id: string } }>) {
+  const { params } = await props;
   const { id } = params;
   const item = await fetchCccdDetail(id);
 

--- a/src/app/cccd/[id]/page.tsx
+++ b/src/app/cccd/[id]/page.tsx
@@ -4,9 +4,8 @@ import { fetchCccdDetail } from "@/lib/api";
 
 export const dynamic = "force-dynamic";
 
-export default async function CccdDetailPage(props: Promise<{ params: { id: string } }>) {
-  const { params } = await props;
-  const { id } = params;
+export default async function CccdDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
   const item = await fetchCccdDetail(id);
 
   return (


### PR DESCRIPTION
## Purpose
Fix TypeScript build error in production where the `params` property type was incompatible. The error occurred because Next.js expects `params` to be a Promise in async page components, but it was typed as a plain object.

## Code changes
- Updated `params` type from `{ id: string }` to `Promise<{ id: string }>` in CccdDetailPage component
- Added `await` when destructuring the `id` parameter from `params`
- Ensures compatibility with Next.js async page component requirementsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/919aef0f7b144ceb8a06c1e5eb4091c3/vibe-haven)

👀 [Preview Link](https://919aef0f7b144ceb8a06c1e5eb4091c3-vibe-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>919aef0f7b144ceb8a06c1e5eb4091c3</projectId>-->
<!--<branchName>vibe-haven</branchName>-->